### PR TITLE
22 reduce unneeded parameters in search  url

### DIFF
--- a/Classes/ViewHelpers/SearchUriViewHelper.php
+++ b/Classes/ViewHelpers/SearchUriViewHelper.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Slub\LisztCommon\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+
+class SearchUriViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('searchParams', 'array', 'Search parameters', true);
+        $this->registerArgument('pageUid', 'int', 'Target page UID', false);
+        $this->registerArgument('addCHash', 'bool', 'Add cHash', false, false);
+        $this->registerArgument('wrapInSearchParams', 'bool', 'Wrap parameters in searchParams key for backward compatibility', false, true);
+    }
+
+    public function render(): string
+    {
+        $searchParams = $this->arguments['searchParams'];
+        $pageUid = $this->arguments['pageUid'];
+        $addCHash = $this->arguments['addCHash'];
+        $wrapInSearchParams = $this->arguments['wrapInSearchParams'];
+
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $uriBuilder->reset();
+
+        if ($pageUid) {
+            $uriBuilder->setTargetPageUid($pageUid);
+        }
+
+        // Wrap parameters in 'searchParams' for backward compatibility with existing controller
+        $pluginParams = $wrapInSearchParams ? ['searchParams' => $searchParams] : $searchParams;
+
+        $additionalParams = [
+            'tx_liszt_common_searchlisting' => $pluginParams
+        ];
+
+        $uri = $uriBuilder
+            ->setArguments($additionalParams)
+            ->setCreateAbsoluteUri(false)
+            ->setAddQueryString(false)
+            ->build();
+
+        // Remove cHash if not wanted
+        if (!$addCHash && str_contains($uri, 'cHash=')) {
+            $uri = preg_replace('/&cHash=[^&]*/', '', $uri);
+            $uri = preg_replace('/\?cHash=[^&]*&/', '?', $uri);
+            $uri = preg_replace('/\?cHash=[^&]*$/', '', $uri);
+        }
+
+        return $uri;
+    }
+}

--- a/Classes/ViewHelpers/SearchUriViewHelper.php
+++ b/Classes/ViewHelpers/SearchUriViewHelper.php
@@ -13,7 +13,7 @@ class SearchUriViewHelper extends AbstractViewHelper
     {
         $this->registerArgument('searchParams', 'array', 'Search parameters', true);
         $this->registerArgument('pageUid', 'int', 'Target page UID', false);
-        $this->registerArgument('addCHash', 'bool', 'Add cHash', false, false);
+     //   $this->registerArgument('removeCHash', 'bool', 'Remove cHash', false, false);
         $this->registerArgument('wrapInSearchParams', 'bool', 'Wrap parameters in searchParams key for backward compatibility', false, true);
     }
 
@@ -21,7 +21,7 @@ class SearchUriViewHelper extends AbstractViewHelper
     {
         $searchParams = $this->arguments['searchParams'];
         $pageUid = $this->arguments['pageUid'];
-        $addCHash = $this->arguments['addCHash'];
+     //   $removeCHash = $this->arguments['removeCHash'];
         $wrapInSearchParams = $this->arguments['wrapInSearchParams'];
 
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
@@ -44,12 +44,14 @@ class SearchUriViewHelper extends AbstractViewHelper
             ->setAddQueryString(false)
             ->build();
 
+        // cHash would be disabled in Settings->Configure Installation-Wide Options->[FE][cacheHash][excludedParameters] -> ^tx_liszt_common_searchlisting[
+
         // Remove cHash if not wanted
-        if (!$addCHash && str_contains($uri, 'cHash=')) {
-            $uri = preg_replace('/&cHash=[^&]*/', '', $uri);
-            $uri = preg_replace('/\?cHash=[^&]*&/', '?', $uri);
-            $uri = preg_replace('/\?cHash=[^&]*$/', '', $uri);
-        }
+//       if ($removeCHash && str_contains($uri, 'cHash=')) {
+//            $uri = preg_replace('/&cHash=[^&]*/', '', $uri);
+//            $uri = preg_replace('/\?cHash=[^&]*&/', '?', $uri);
+//            $uri = preg_replace('/\?cHash=[^&]*$/', '', $uri);
+//        }
 
         return $uri;
     }

--- a/Configuration/Routing/routeEnhancers.yaml
+++ b/Configuration/Routing/routeEnhancers.yaml
@@ -1,4 +1,4 @@
-#Attention: the value for will be overwritten with detailPageId from extension config in SiteConfigurationLoadedEventListener
+#Attention: the value for limitToPages will be overwritten with detailPageId from extension config in SiteConfigurationLoadedEventListener
 routeEnhancers:
   SearchDetailsRoute:
     type: Extbase

--- a/Resources/Private/Partials/FilterBlock.html
+++ b/Resources/Private/Partials/FilterBlock.html
@@ -31,7 +31,6 @@
                             <div class="slider-handle handle-max" data-type="max"></div>
                         </div>
                         <lc:cleanUrlForm class="filter-slider-input" controller="Search" action="index" method="get" pluginName="SearchListing" >
-
                             <f:comment> Known issue in TYPO3 v12 - Bug #100583, 'addQueryString' and 'additionalParams' in form Tag do not work as expected. therefore for the time being the solution with hidden input</f:comment>
                             <lc:renderHiddenFields data="{searchParamsFromFirstPage}" namePrefix="tx_liszt_common_searchlisting[searchParams]" />
 
@@ -41,15 +40,11 @@
                             </div>
                             <f:form.button class="btn btn-black filter-slider-button filter-slider-submit" >{f:translate(key: 'filter_submit', extensionName: 'liszt_common')}</f:form.button>
                             <f:if condition="{searchParams.filter.{key}}">
-                                <f:link.action
-                                    action="index"
-                                    controller="Search"
-                                    additionalAttributes="{'type': 'button'}"
-                                    pluginName="SearchListing"
-                                    arguments="{lc:searchParams(action: 'removeRangeFilter', searchParamsArray: searchParamsFromFirstPage, key: key)}"
-                                    class="btn btn-black filter-slider-button filter-slider-reset">
+                                <f:variable name="linkArguments">{lc:searchParams(action: 'removeRangeFilter', searchParamsArray: searchParamsFromFirstPage, key: key)}</f:variable>
+                                <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+                                   type="button" class="btn btn-black filter-slider-button filter-slider-reset">
                                     {f:translate(key: 'filter_reset', extensionName: 'liszt_common')}
-                                </f:link.action>
+                                </a>
                             </f:if>
                         </lc:cleanUrlForm>
                     </div>

--- a/Resources/Private/Partials/FilterBlockItem.html
+++ b/Resources/Private/Partials/FilterBlockItem.html
@@ -1,18 +1,16 @@
 {namespace lc=Slub\LisztCommon\ViewHelpers}
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:variable name="searchParamsAction" value="{filter.selected ? 'removeFilter' : 'addFilter'}" />
-            <li class="{f:if(condition: '{filter.hidden}', then: 'hidden', else: '')}">
-                <f:if condition="{filter.key}">
-                        <f:link.action
-                            action="index"
-                            controller="Search"
-                            pluginName="SearchListing"
-                            title="{f:if(condition: '{filter.selected}', then: '{f:translate(key:\'filter_remove_item\')}', else: '{f:translate(key:\'filter_add_item\')}')}"
-                            arguments="{lc:searchParams(action: searchParamsAction, searchParamsArray: searchParamsFromFirstPage, key: key, value: filter.key)}"
-                            class="filter-item {f:if(condition: '{filter.selected}', then: 'selected', else: '')} {f:if(condition: '{filter.hidden}', then: 'hidden', else: '')}">
-                            <span class="filter-item-label">{f:translate(key: '{languageFilePath}:{key}_{filter.key}', default: '{filter.key}')}</span>
-                            <span class="filter-item-count">{filter.doc_count}</span>
-                        </f:link.action>
-                </f:if>
-            </li>
+<li class="{f:if(condition: '{filter.hidden}', then: 'hidden', else: '')}">
+    <f:if condition="{filter.key}">
+        <f:variable name="linkArguments">{lc:searchParams(action: searchParamsAction, searchParamsArray: searchParamsFromFirstPage, key: key, value: filter.key)}</f:variable>
+
+        <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+           title="{f:if(condition: '{filter.selected}', then: '{f:translate(key:\'filter_remove_item\')}', else: '{f:translate(key:\'filter_add_item\')}')}"
+           class="filter-item {f:if(condition: '{filter.selected}', then: 'selected', else: '')} {f:if(condition: '{filter.hidden}', then: 'hidden', else: '')}">
+            <span class="filter-item-label">{f:translate(key: '{languageFilePath}:{key}_{filter.key}', default: '{filter.key}')}</span>
+            <span class="filter-item-count">{filter.doc_count}</span>
+        </a>
+    </f:if>
+</li>
 </html>

--- a/Resources/Private/Partials/Pagination.html
+++ b/Resources/Private/Partials/Pagination.html
@@ -11,9 +11,26 @@
                         </span>
                     </f:then>
                     <f:else>
-                        <f:link.action action="index" controller="Search" pluginName="SearchListing" arguments="{lc:searchParams(action: 'add', searchParamsArray: searchParams, key: 'page', value: page.page)}" additionalAttributes="{f:if(condition: '{page.class} == {currentString}', then: '{aria-current: \'page\', aria-label: \'{f:translate(key: \\\'searchResults_pagination_currentPage\\\',  arguments: {0: page.page}, extensionName: \\\'liszt_common\\\')}\' }', else:'{aria-label: \'{f:translate(key: \\\'searchResults_pagination_gotoPage\\\',  arguments: {0: page.page}, extensionName: \\\'liszt_common\\\')}\' }' )}">
-                            {page.page}
-                        </f:link.action>
+                        <f:variable name="linkArguments">{lc:searchParams(action: 'add', searchParamsArray: searchParams, key: 'page', value: page.page)}</f:variable>
+                        <f:variable name="isCurrentPage" value="{f:if(condition: '{page.class} == {currentString}', then: 1, else: 0)}"/>
+                        <f:if condition="{isCurrentPage}">
+                            <f:then>
+                                <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+                                   aria-current="page"
+                                   aria-label="{f:translate(key: 'searchResults_pagination_currentPage', arguments: {0: page.page}, extensionName: 'liszt_common')}"
+                                >
+                                    {page.page}
+                                </a>
+                            </f:then>
+                            <f:else>
+                                <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+                                   aria-label="{f:translate(key: 'searchResults_pagination_gotoPage', arguments: {0: page.page}, extensionName: 'liszt_common')}"
+                                >
+                                    {page.page}
+                                </a>
+                            </f:else>
+                        </f:if>
+
                     </f:else>
                 </f:if>
             </li>

--- a/Resources/Private/Templates/Search/Index.html
+++ b/Resources/Private/Templates/Search/Index.html
@@ -1,8 +1,7 @@
-
 {namespace lc=Slub\LisztCommon\ViewHelpers}
 <html
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-    xmlns:i="http://typo3.org/ns/Quellenform/Iconpack/ViewHelpers"
+    xmlns:i="http://typo3.org/ns/Quellenform/Iconpack/ViewHelpers" xmlns:
     data-namespace-typo3-fluid="true">
 <f:variable name="languageFilePath">LLL:EXT:{settings.entityTypes.1.extensionName}/Resources/Private/Language/{settings.entityTypes.1.languageFile}.xlf</f:variable>
 <f:variable name="paramsRemovePage">{lc:searchParams(action: 'remove', searchParamsArray: searchParams, key: 'page')}</f:variable>
@@ -26,32 +25,26 @@
                             <f:if condition="{isFulltext}">
                                 <li>
                                     <f:variable name="isActive" value="{f:if(condition: '{searchParams.sort} == {sorting.label}', then: 1, else: '{f:if(condition: \'{hasSelectedSort} == 0 && {sorting.defaultFulltext}\', then: 1, else: 0)}')}"/>
-                                    <f:link.action
-                                        action="index"
-                                        controller="Search"
-                                        pluginName="SearchListing"
-                                        additionalAttributes="{f:if(condition:'{isActive}',then:{aria-current:'true'})}"
-                                        arguments="{lc:searchParams(action: 'add', searchParamsArray: searchParamsFromFirstPage, key: 'sort', value: sorting.label)}"
-                                        class="dropdown-button-item {f:if(condition: isActive, then: 'active')}"
+                                    <f:variable name="linkArguments">{lc:searchParams(action: 'add', searchParamsArray: searchParamsFromFirstPage, key: 'sort', value: sorting.label)}</f:variable>
+                                    <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+                                       {f:if(condition:'{isActive}',then:'aria-current="true"')}
+                                    class="dropdown-button-item {f:if(condition: isActive, then: 'active')}"
                                     >
-                                        {f:translate(key: '{languageFilePath}:{sorting.label}', default: '{sorting.label}')}
-                                    </f:link.action>
+                                    {f:translate(key: '{languageFilePath}:{sorting.label}', default: '{sorting.label}')}
+                                    </a>
                                 </li>
                             </f:if>
                         </f:then>
                         <f:else>
                             <li>
                                 <f:variable name="isActive" value="{f:if(condition: '{searchParams.sort} == {sorting.label}', then: 1, else: '{f:if(condition: \'{hasSelectedSort} == 0 && {sorting.default} && {isFulltext} == 0\', then: 1, else: 0)}')}"/>
-                                <f:link.action
-                                    action="index"
-                                    controller="Search"
-                                    pluginName="SearchListing"
-                                    additionalAttributes="{f:if(condition:'{isActive}',then:{aria-current:'true'})}"
-                                    arguments="{lc:searchParams(action: 'add', searchParamsArray: searchParamsFromFirstPage, key: 'sort', value: sorting.label)}"
-                                    class="dropdown-button-item {f:if(condition: isActive, then: 'active')}"
+                                <f:variable name="linkArguments">{lc:searchParams(action: 'add', searchParamsArray: searchParamsFromFirstPage, key: 'sort', value: sorting.label)}</f:variable>
+                                <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}"
+                                   {f:if(condition:'{isActive}',then:'aria-current="true"')}
+                                class="dropdown-button-item {f:if(condition: isActive, then: 'active')}"
                                 >
                                     {f:translate(key: '{languageFilePath}:{sorting.label}', default: '{sorting.label}')}
-                                </f:link.action>
+                                </a>
                             </li>
                         </f:else>
                     </f:if>
@@ -82,15 +75,13 @@
                             <span>{f:translate(key: '{languageFilePath}:{key}_{innerKey}', default: '{innerKey}')}</span>
                           </f:else>
                       </f:if>
-                    <f:link.action action="index" controller="Search" pluginName="SearchListing"
-                                   arguments="{lc:searchParams(action: 'removeFilter', searchParamsArray: searchParamsFromFirstPage, key: key, value: innerKey)}"
-                                   additionalAttributes="{type:'button'}"
-                                   class="tag-cross">
+                    <f:variable name="linkArguments">{lc:searchParams(action: 'removeFilter', searchParamsArray: searchParamsFromFirstPage, key: key, value: innerKey)}</f:variable>
+                     <a href="{lc:searchUri(searchParams: linkArguments.searchParams)}" type="button" class="tag-cross">
                         <span class="visually-hidden">{f:translate(key: 'searchResults_params_remove_label', arguments: {0: innerKey}, extensionName: 'liszt_common')}</span>
                         <svg aria-hidden="true" stroke="currentColor" fill="none" viewBox="0 0 8 8">
                             <path stroke-linecap="round" stroke-width="1" d="M1 1l6 6m0-6L1 7"></path>
                         </svg>
-                    </f:link.action>
+                    </a>
                     </span>
                 </f:for>
             </f:for>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -44,12 +44,6 @@ ExtensionUtility::configurePlugin(
     [ ],
 );
 
-ExtensionUtility::configurePlugin(
-    'LisztCommon',
-    'SearchDetailsHeader',
-    [ SearchController::class => 'detailsHeader' ],
-    [ ],
-);
 
 
 ExtensionUtility::configurePlugin(


### PR DESCRIPTION
please check the new URIs
to disable cHash you have to add 
^tx_liszt_common_searchlisting[
to Settings->Configure Installation-Wide Options->[FE][cacheHash][excludedParameters]
in Typo3 Backend

Questions are:
- do we actually need the array searchParams to include the search parameters?
- is it possible to shorten tx_liszt_common_searchlisting?
