### PR TITLE
Remove some tx_listcommon Fields from index and templates

### DIFF
--- a/Classes/Common/QueryParamsBuilder.php
+++ b/Classes/Common/QueryParamsBuilder.php
@@ -2,18 +2,13 @@
 
 namespace Slub\LisztCommon\Common;
 
-use Slub\LisztCommon\Processing\IndexProcessor;
-use Illuminate\Support\Str;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class QueryParamsBuilder
 {
-    const TYPE_FIELD = 'itemType';
-    const HEADER_FIELD = 'tx_lisztcommon_header';
-    const FOOTER_FIELD = 'tx_lisztcommon_footer';
-    const BODY_FIELD = 'tx_lisztcommon_body';
-    const SEARCHABLE_FIELD = 'tx_lisztcommon_searchable';
+//    const TYPE_FIELD = 'itemType';
+//    const SEARCHABLE_FIELD = 'tx_lisztcommon_searchable';
 
     protected array $params = [];
     protected array $settings = [];
@@ -76,15 +71,7 @@ class QueryParamsBuilder
 
         $this->query = [
             'size' => $commonConf['itemsPerPage'],
-            'body' => [
-/*                '_source' => [
-                    IndexProcessor::TYPE_FIELD,
-                    IndexProcessor::HEADER_FIELD,
-                    IndexProcessor::BODY_FIELD,
-                    IndexProcessor::FOOTER_FIELD,
-                    IndexProcessor::SEARCHABLE_FIELD
-                ],*/
-            ]
+            'body' => []
         ];
 
         if ($this->searchAll == false) {
@@ -137,16 +124,6 @@ class QueryParamsBuilder
         return $this->query;
     }
 
-    private function getIndexName(): string
-    {
-        if (isset($this->params['index'])) {
-            return $this->params['index'];
-        }
-        return Collection::wrap($this->settings)->
-            get('entityTypes')->
-            pluck('indexName')->
-            join(',');
-    }
 
     private function getAggregations($settings): array
     {

--- a/Classes/Processing/IndexProcessor.php
+++ b/Classes/Processing/IndexProcessor.php
@@ -17,9 +17,6 @@ abstract class IndexProcessor
 {
 
     const TYPE_FIELD = 'itemType';
-    const HEADER_FIELD = 'tx_lisztcommon_header';
-    const FOOTER_FIELD = 'tx_lisztcommon_footer';
-    const BODY_FIELD = 'tx_lisztcommon_body';
     const SEARCHABLE_FIELD = 'tx_lisztcommon_searchable';
     const BOOSTED_FIELD = 'tx_lisztcommon_boosted';
 

--- a/Resources/Private/Templates/Search/DetailsHeader.html
+++ b/Resources/Private/Templates/Search/DetailsHeader.html
@@ -1,12 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-
 <div class="page-header-title page-header-title-detailpage">
-    <f:if condition="{searchResult._source.tx_lisztcommon_header}">
-        <p class="page-header-subtitle"  style="view-transition-name: detail-sub-{searchResult._id};">Generischer Details Header</p>
-    </f:if>
-    <h1 style="view-transition-name: detail-headline-{searchResult._id};">
-        <f:format.nl2br>Kein Template "DetailPageHeader" in Extension vorhanden</f:format.nl2br>
-    </h1>
+    <p class="page-header-subtitle"  style="view-transition-name: detail-sub-{searchResult._id};">Generischer Details Header</p>
+    <h1 style="view-transition-name: detail-headline-{searchResult._id};">Kein Template "DetailPageHeader" in Extension vorhanden</h1>
 </div>
-
 </html>


### PR DESCRIPTION
I removed tx lisztcommon body, title, and footer from the code and fixed a bug in the detail page navigation. Reindexing is necessary, and the tests will probably need to be adjusted again ;-)